### PR TITLE
当客户端sdk提示与服务器版本不一致时，告知如何生成匹配版本的sdk #949

### DIFF
--- a/cocos2d-js-client/src/cc_scripts/StartScene.js
+++ b/cocos2d-js-client/src/cc_scripts/StartScene.js
@@ -559,7 +559,8 @@ var StartSceneLayer = cc.Layer.extend({
 
     onVersionNotMatch : function(clientVersion, serverVersion)
     {
-    	GUIDebugLayer.debug.ERROR_MSG("Version not match(curr=" + clientVersion + ", srv=" + serverVersion + " )(版本不匹配)");	
+        GUIDebugLayer.debug.ERROR_MSG("Version not match(curr=" + clientVersion + ", srv=" + serverVersion + " )(版本不匹配)");	
+        KBEngine.ERROR_MSG("Execute the gensdk script to generate matching client SDK in the server-assets directory.");
         this.serverScriptVersion.setString("serverScriptVersion: " + KBEngine.app.serverScriptVersion);
         this.serverVersion.setString("serverVersion: " + KBEngine.app.serverVersion);	    	
     },


### PR DESCRIPTION
https://github.com/kbengine/kbengine/issues/949